### PR TITLE
Update prettier module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7937,9 +7937,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.8.2.tgz",
-      "integrity": "sha512-fHWjCwoRZgjP1rvLP7OGqOznq7xH1sHMQUFLX8qLRO79hI57+6xbc5vB904LxEkCfgFgyr3vv06JkafgCSzoZg==",
+      "version": "1.13.7",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.13.7.tgz",
+      "integrity": "sha512-KIU72UmYPGk4MujZGYMFwinB7lOf2LsDNGSOC8ufevsrPLISrZbNJlWstRi3m0AMuszbH+EFSQ/r6w56RSPK6w==",
       "dev": true
     },
     "pretty-format": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "lint-staged": "^7.0.0",
     "moment": "^2.21.0",
     "pre-commit": "^1.2.2",
-    "prettier": "^1.7.4",
+    "prettier": "^1.13.7",
     "prop-types": "^15.6.1",
     "react": "^16.2.0",
     "react-codemirror2": "^5.0.1",


### PR DESCRIPTION
Fixes an issue where [prettier-vscode](https://github.com/prettier/prettier-vscode) expected prettier 1.9 and would error on settings, such as "proseWrap" with a mismatch between types.